### PR TITLE
Work for 0.24.x release candidate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.144.77</version>
+        <version>0.146.6</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin.java.catalog</groupId>
     <artifactId>catalog-test</artifactId>
@@ -42,8 +42,7 @@
     </issueManagement>
     <properties>
         <check.skip-spotbugs>true</check.skip-spotbugs>
-        <killbill-base-plugin.version>4.2.18</killbill-base-plugin.version>
-        <killbill.version>0.22.29</killbill.version>
+        <killbill.version>0.24.0</killbill.version>
         <osgi.private>org.killbill.billing.plugin.catalog.*</osgi.private>
     </properties>
     <dependencies>
@@ -69,8 +68,8 @@
             <artifactId>swagger-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -89,7 +88,6 @@
         <dependency>
             <groupId>org.kill-bill.billing</groupId>
             <artifactId>killbill-catalog</artifactId>
-            <version>${killbill.version}</version>
         </dependency>
         <dependency>
             <groupId>org.kill-bill.billing</groupId>
@@ -119,8 +117,9 @@
             <artifactId>killbill-base-plugin</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.compendium</artifactId>
+            <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-utils</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/org/killbill/billing/plugin/catalog/CatalogActivator.java
+++ b/src/main/java/org/killbill/billing/plugin/catalog/CatalogActivator.java
@@ -25,11 +25,14 @@ import org.killbill.billing.osgi.libs.killbill.KillbillActivatorBase;
 import org.killbill.billing.plugin.api.notification.PluginConfigurationEventHandler;
 import org.killbill.billing.plugin.core.config.PluginEnvironmentConfig;
 import org.osgi.framework.BundleContext;
-import org.osgi.service.log.LogService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Hashtable;
 
 public class CatalogActivator extends KillbillActivatorBase {
+
+    private final Logger logger = LoggerFactory.getLogger(CatalogActivator.class);
 
     public static final String PLUGIN_NAME = "killbill-catalog-test";
 
@@ -39,7 +42,7 @@ public class CatalogActivator extends KillbillActivatorBase {
     public void start(final BundleContext context) throws Exception {
         super.start(context);
 
-        logService.log(LogService.LOG_INFO, "Starting " + PLUGIN_NAME);
+        logger.info("Starting {}", PLUGIN_NAME);
 
         final String region = PluginEnvironmentConfig.getRegion(configProperties.getProperties());
         configurationHandler = new CatalogConfigurationHandler(region, PLUGIN_NAME, killbillAPI);

--- a/src/main/java/org/killbill/billing/plugin/catalog/json/conversions/CatalogJsonToStaticCatalog.java
+++ b/src/main/java/org/killbill/billing/plugin/catalog/json/conversions/CatalogJsonToStaticCatalog.java
@@ -391,12 +391,10 @@ public class CatalogJsonToStaticCatalog implements Function<CatalogJson, StaticC
     private Limit toLimit(final Map<String, Unit> units, final CatalogJson.LimitJson input) {
         Limit output = null;
         if (input != null) {
-            Double max = Utils.toDouble(input.getMax());
-            Double min = Utils.toDouble(input.getMin());
             Unit unit = lookupUnit(units, input.getUnit());
             output = new LimitModel.Builder<>()
-                    .withMax(max)
-                    .withMin(min)
+                    .withMax(new BigDecimal(input.getMax()))
+                    .withMin(new BigDecimal(input.getMin()))
                     .withUnit(unit)
                     .build();
         }
@@ -416,18 +414,14 @@ public class CatalogJsonToStaticCatalog implements Function<CatalogJson, StaticC
     private TieredBlock toTieredBlock(final Map<String, Unit> units, final CatalogJson.TieredBlockJson input) {
         TieredBlock output = null;
         if (input != null) {
-            Double max = Utils.toDouble(input.getMax());
-            Double minTopUpCredit = missingTieredBlockMinTopUpCredit;
             InternationalPrice price = toInternationalPrice(input.getPrices());
-            Double size = Utils.toDouble(input.getSize());
-            BlockType type = missingTieredBlockType;
             Unit unit = lookupUnit(units, input.getUnit());
             output = new TieredBlockModel.Builder<>()
-                    .withMax(max)
-                    .withMinTopUpCredit(minTopUpCredit)
+                    .withMax(new BigDecimal(input.getMax()))
+                    .withMinTopUpCredit(BigDecimal.valueOf((missingTieredBlockMinTopUpCredit == null ? 0d : missingTieredBlockMinTopUpCredit)))
                     .withPrice(price)
-                    .withSize(size)
-                    .withType(type)
+                    .withSize(new BigDecimal(input.getSize()))
+                    .withType(missingTieredBlockType)
                     .withUnit(unit)
                     .build();
         }

--- a/src/test/java/org/killbill/billing/plugin/catalog/TestCatalogTestPluginApi.java
+++ b/src/test/java/org/killbill/billing/plugin/catalog/TestCatalogTestPluginApi.java
@@ -26,7 +26,7 @@ import org.killbill.billing.catalog.plugin.api.StandalonePluginCatalog;
 import org.killbill.billing.catalog.plugin.api.VersionedPluginCatalog;
 import org.killbill.billing.util.callcontext.TenantContext;
 import org.killbill.billing.util.callcontext.boilerplate.TenantContextImp;
-import org.killbill.billing.util.io.IOUtils;
+import org.killbill.commons.utils.io.IOUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;


### PR DESCRIPTION
- Dependency to osgi.compedium get removed. The only class that use it is `CatalogActivator` that use `LogService`, and it get refactored to use SLF4J directly.

- There's one [FIXME](https://github.com/killbill/killbill-catalog-plugin-test/compare/work-for-release-0.23.x...xsalefter:killbill-catalog-plugin-test:work-for-0.24.x-release-candidate?expand=1#diff-a30b19f512055bced3501ee00372e908f7ac94c9da07622419b9a7f9fac7edebR417) that I don't understand. I'll update once someone confirm about it.