### PR TITLE
Added default configuration (fix for issue while creating new tenant)

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/catalog/CatalogActivator.java
+++ b/src/main/java/org/killbill/billing/plugin/catalog/CatalogActivator.java
@@ -52,6 +52,8 @@ public class CatalogActivator extends KillbillActivatorBase {
 
         final String region = PluginEnvironmentConfig.getRegion(configProperties.getProperties());
         configurationHandler = new CatalogConfigurationHandler(region, PLUGIN_NAME, killbillAPI);
+        final CatalogConfiguration defaultConfiguration = createCatalogConfig("WeaponsHire.xml");
+        configurationHandler.setDefaultConfigurable(defaultConfiguration);
 
         final CatalogPluginApi catalogPluginApi = new CatalogPluginApiImpl(configurationHandler, killbillAPI);
         registerCatalogPluginApi(context, catalogPluginApi);
@@ -101,5 +103,13 @@ public class CatalogActivator extends KillbillActivatorBase {
         final Hashtable<String, String> props = new Hashtable<String, String>();
         props.put(OSGIPluginProperties.PLUGIN_NAME_PROP, PLUGIN_NAME);
         registrar.registerService(context, Healthcheck.class, healthcheck, props);
+    }
+
+    private static CatalogConfiguration createCatalogConfig(final String uri) {
+        final String raw = String.format("!!org.killbill.billing.plugin.catalog.CatalogYAMLConfiguration\n" +
+                "  uri: %s\n" +
+                "  validateAccount: false\n" +
+                "  accountCatalog: true", uri);
+        return CatalogConfigurationHandler.fromYAML(raw);
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/catalog/CatalogActivator.java
+++ b/src/main/java/org/killbill/billing/plugin/catalog/CatalogActivator.java
@@ -109,7 +109,7 @@ public class CatalogActivator extends KillbillActivatorBase {
         final String raw = String.format("!!org.killbill.billing.plugin.catalog.CatalogYAMLConfiguration\n" +
                 "  uri: %s\n" +
                 "  validateAccount: false\n" +
-                "  accountCatalog: true", uri);
+                "  accountCatalog: false", uri);
         return CatalogConfigurationHandler.fromYAML(raw);
     }
 }


### PR DESCRIPTION
There is an issue in creating a new tenant when the catalog test plugin is installed. It fails with the following error:

```
java.lang.NullPointerException: Both parameters are null
	at com.google.common.base.MoreObjects.firstNonNull(MoreObjects.java:88)
	at org.killbill.billing.plugin.api.notification.PluginTenantConfigurable.get(PluginTenantConfigurable.java:59)
	at org.killbill.billing.plugin.core.config.YAMLPluginTenantConfigurationHandler.getConfigurable(YAMLPluginTenantConfigurationHandler.java:105)
	at org.killbill.billing.plugin.catalog.CatalogPluginApiImpl.getVersionedPluginCatalog(CatalogPluginApiImpl.java:70)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.killbill.billing.osgi.ContextClassLoaderHelper$ClassLoaderInvocationHandler$1.execute(ContextClassLoaderHelper.java:146)
	at org.killbill.commons.profiling.Profiling.executeWithProfiling(Profiling.java:35)
	at org.killbill.billing.osgi.ContextClassLoaderHelper$ClassLoaderInvocationHandler.handleInvocation(ContextClassLoaderHelper.java:143)
	at org.killbill.commons.utils.reflect.AbstractInvocationHandler.invoke(AbstractInvocationHandler.java:91)
	at com.sun.proxy.$Proxy369.getVersionedPluginCatalog(Unknown Source)
	at org.killbill.billing.catalog.caching.DefaultCatalogCache.getCatalogFromPlugins(DefaultCatalogCache.java:171)
	at org.killbill.billing.catalog.caching.DefaultCatalogCache.getCatalog(DefaultCatalogCache.java:106)
	at org.killbill.billing.catalog.DefaultCatalogService.getCatalog(DefaultCatalogService.java:113)
	at org.killbill.billing.catalog.DefaultCatalogService.getFullCatalog(DefaultCatalogService.java:104)
	at org.killbill.billing.catalog.api.user.DefaultCatalogUserApi.getCurrentStandaloneCatalogForTenant(DefaultCatalogUserApi.java:195)
	at org.killbill.billing.catalog.api.user.DefaultCatalogUserApi.createDefaultEmptyCatalog(DefaultCatalogUserApi.java:144)
	at org.killbill.billing.util.glue.KillbillApiAopModule$ProfilingMethodInterceptor$1.execute(KillbillApiAopModule.java:89)
	at org.killbill.commons.profiling.Profiling.executeWithProfiling(Profiling.java:35)
	at org.killbill.billing.util.glue.KillbillApiAopModule$ProfilingMethodInterceptor.invoke(KillbillApiAopModule.java:105)
	at org.killbill.billing.util.security.AopAllianceMethodInvocationAdapter.proceed(AopAllianceMethodInvocationAdapter.java:45)
	at org.apache.shiro.authz.aop.AuthorizingAnnotationMethodInterceptor.invoke(AuthorizingAnnotationMethodInterceptor.java:68)
	at org.killbill.billing.util.security.AopAllianceMethodInterceptorAdapter.invoke(AopAllianceMethodInterceptorAdapter.java:32)
	at org.killbill.billing.jaxrs.resources.TenantResource.createTenant(TenantResource.java:150)
	at org.killbill.billing.jaxrs.resources.TenantResource_$$_jvsta90_2._d15createTenant(TenantResource_$$_jvsta90_2.java)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.glassfish.hk2.utilities.reflection.ReflectionHelper.invoke(ReflectionHelper.java:1268)
	at org.jvnet.hk2.internal.MethodInterceptorHandler$MethodInvocationImpl.proceed(MethodInterceptorHandler.java:164)
	at org.killbill.commons.skeleton.metrics.TimedResourceInterceptor.invoke(TimedResourceInterceptor.java:70)
	at org.jvnet.hk2.internal.MethodInterceptorHandler.invoke(MethodInterceptorHandler.java:97)
	at org.killbill.billing.jaxrs.resources.TenantResource_$$_jvsta90_2.createTenant(TenantResource_$$_jvsta90_2.java)

```

On investigating this further,  I found that the error occurs because there is no default configuration for the newly created tenant. So, I've added this fix. 

Even for an existing tenant, the default configuration will now be used if one is not explicitly specified.